### PR TITLE
Feat/add user reset password workflow

### DIFF
--- a/app/Console/Commands/CleanPasswordResetTokens.php
+++ b/app/Console/Commands/CleanPasswordResetTokens.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class CleanPasswordResetTokens extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:clean-password-reset-tokens';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clean expired password reset tokens';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        DB::table('password_reset_tokens')
+            ->where('expires_at', '<', now())
+            ->delete();
+
+        $this->info('Expired password reset tokens cleaned.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,6 +13,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         // $schedule->command('inspire')->hourly();
+        $schedule->command('app:clean-password-reset-tokens')->hourly();
     }
 
     /**

--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AuthenticationController extends Controller
+{
+    public function register()
+    {
+        return view('pages.auth.register', ['title' => 'Sign up']);
+    }
+
+    public function login()
+    {
+        return view('pages.auth.login', ['title' => 'Sign in']);
+    }
+
+    public function forgotPassword()
+    {
+        return view('pages.auth.forgot-password', ['title' => 'Forgot your password?']);
+    }
+}

--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -2,22 +2,62 @@
 
 namespace App\Http\Controllers;
 
+use App\Repositories\Interfaces\UserRepositoryInterface;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class AuthenticationController extends Controller
 {
+    protected UserRepositoryInterface $userRepository;
+
+    public function __construct(
+        UserRepositoryInterface $userRepository
+    ) {
+        $this->userRepository = $userRepository;
+    }
+
     public function register()
     {
-        return view('pages.auth.register', ['title' => 'Sign up']);
+        return view('pages.auth.register', ['title' => __('pages/auth/register.title')]);
     }
 
     public function login()
     {
-        return view('pages.auth.login', ['title' => 'Sign in']);
+        return view('pages.auth.login', ['title' => __('pages/auth/login.title')]);
     }
 
     public function forgotPassword()
     {
-        return view('pages.auth.forgot-password', ['title' => 'Forgot your password?']);
+        return view('pages.auth.forgot-password', ['title' => __('pages/auth/forgot-password.title')]);
+    }
+
+    public function resetPassword(Request $request, string $token = null)
+    {
+        try {
+            $token = $request->route('token');
+            $email = $request->input('email');
+
+            if (!$token || !$email) return $this->redirectToForgotPassword();
+
+            $user = $this->userRepository->findByEmail($email);
+            $tokenRecord = DB::table('password_reset_tokens')->where('email', $email)->first();
+
+            if (!$tokenRecord || $tokenRecord->token != $token) return $this->redirectToForgotPassword();
+
+            return view('pages.auth.reset-password', [
+                'title' => __('pages/auth/reset-password.title'),
+                'token' => $token,
+                'user' => $user,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Error on reset password: ' . $e->getMessage());
+            return $this->redirectToForgotPassword();
+        }
+    }
+
+    private function redirectToForgotPassword()
+    {
+        return redirect()->route('auth.forgot-password', ['locale' => app()->getLocale()]);
     }
 }

--- a/app/Livewire/ForgotPasswordUser.php
+++ b/app/Livewire/ForgotPasswordUser.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Livewire;
+
+use Illuminate\Support\Str;
+use Livewire\Component;
+use App\Livewire\Forms\ForgotPassowordUserForm;
+use App\Mail\ResetUserPasswordMail;
+use App\Repositories\Interfaces\UserRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class ForgotPasswordUser extends Component
+{
+    public ForgotPassowordUserForm $form;
+    protected UserRepositoryInterface $userRepository;
+
+    public function sendEmail()
+    {
+        $this->form->validate();
+        try {
+            $user = $this->userRepository->findByEmail($this->form->email);
+            $token = hash_hmac('sha256', Str::random(40), config('app.key'));
+
+            DB::table('password_reset_tokens')->updateOrInsert(
+                ['email' => $user->email],
+                ['email' => $user->email, 'token' => $token, 'created_at' => now()]
+            );
+
+            $mail = new ResetUserPasswordMail(name: $user->name, email: $user->email, token: $token);
+
+            Mail::to($user->email)->send($mail);
+
+            $this->form->reset();
+            return session()->flash('success', __('pages/auth/forgot-password.messages.success'));
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+            return session()->flash('error', __('pages/auth/forgot-password.messages.error'));
+        }
+    }
+
+    public function booted(UserRepositoryInterface $userRepository)
+    {
+        $this->userRepository = $userRepository;
+    }
+
+    public function render()
+    {
+        return view('livewire.forgot-password-user');
+    }
+}

--- a/app/Livewire/Forms/ForgotPassowordUserForm.php
+++ b/app/Livewire/Forms/ForgotPassowordUserForm.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Livewire\Forms;
+
+use Livewire\Attributes\Rule;
+use Livewire\Form;
+
+class ForgotPassowordUserForm extends Form
+{
+    public string $email = '';
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email|exists:users,email',
+        ];
+    }
+
+    /**
+     * Get custom error messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages(): array
+    {
+        return [
+            'email.required' => __('validation.required', ['attribute' => __('pages/auth/forgot-password.attributes.email')]),
+            'email.exists' => __('validation.exists', ['attribute' => __('pages/auth/forgot-password.attributes.email')]),
+            'email.email' => __('validation.email', ['attribute' => __('pages/auth/forgot-password.attributes.email')]),
+        ];
+    }
+
+    public function render()
+    {
+        return view("livewire.forgot-password");
+    }
+}

--- a/app/Livewire/Forms/ResetPasswordUserForm.php
+++ b/app/Livewire/Forms/ResetPasswordUserForm.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Livewire\Forms;
+
+use Illuminate\Validation\Rule as ValidationRule;
+use Livewire\Attributes\Rule;
+use Livewire\Form;
+
+class ResetPasswordUserForm extends Form
+{
+    public string $password = '';
+    public string $password_confirmation = '';
+
+    public function rules()
+    {
+        return [
+            'password' => 'required|confirmed|min:8|max:255',
+            'password_confirmation' => 'required|min:8|max:255',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'password.required' => __('validation.required', ['attribute' => __('pages/auth/reset-password.attributes.password')]),
+            'password.min' => __('validation.min.string', ['attribute' => __('pages/auth/reset-password.attributes.password'), 'min' => 8]),
+            'password.max' => __('validation.max.string', ['attribute' => __('pages/auth/reset-password.attributes.password'), 'max' => 255]),
+            'password.confirmed' => __('validation.confirmed', ['attribute' => __('pages/auth/reset-password.attributes.password')]),
+            'password_confirmation.required' => __('validation.required', ['attribute' => __('pages/auth/reset-password.attributes.password_confirmation')]),
+            'password_confirmation.min' => __('validation.min.string', ['attribute' => __('pages/auth/reset-password.attributes.password_confirmation'), 'min' => 8]),
+            'password_confirmation.max' => __('validation.max.string', ['attribute' => __('pages/auth/reset-password.attributes.password_confirmation'), 'max' => 255]),
+        ];
+    }
+
+    public function render()
+    {
+        return view('livewire.reset-password-user');
+    }
+}

--- a/app/Livewire/LoginUser.php
+++ b/app/Livewire/LoginUser.php
@@ -9,19 +9,20 @@ use Livewire\Component;
 
 class LoginUser extends Component
 {
-    public array $credentials = [
-        'email' => '',
-        'password' => '',
-    ];
+    public string $email = '';
+    public string $password = '';
+    public bool $remember_me = false;
 
     public function login()
     {
-        $userAuthenticated = Auth::attempt($this->credentials);
-        $data = ['locale' => app()->getLocale()];
+        $userAuthenticated = Auth::attempt([
+            'email' => $this->email,
+            'password' => $this->password,
+        ], $this->remember_me);
 
         if ($userAuthenticated) {
             request()->session()->regenerate();
-            return redirect()->route('index', $data);
+            return redirect()->route('index', ['locale' => app()->getLocale()]);
         }
 
         return session()->flash('message', __('pages/auth/login.form_error.credentials_error'));

--- a/app/Livewire/ResetPasswordUser.php
+++ b/app/Livewire/ResetPasswordUser.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Livewire\Forms\ResetPasswordUserForm;
+use App\Models\User;
+use App\Repositories\Interfaces\UserRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Livewire\Component;
+
+class ResetPasswordUser extends Component
+{
+    public $token;
+    public $user;
+
+    protected $listeners = ['redirect' => 'redirectEvent'];
+    protected $queryString = ['token', 'email'];
+
+    public ResetPasswordUserForm $form;
+    protected UserRepositoryInterface $userRepository;
+
+    public function booted(
+        UserRepositoryInterface $userRepository
+    ) {
+        $this->userRepository = $userRepository;
+    }
+
+    public function mount(string $token, User $user)
+    {
+        $this->token = $token;
+        $this->user = $user;
+    }
+
+    public function updated(string $propertyName)
+    {
+        $this->validateOnly($propertyName);
+
+        if (filled($this->form->password) && filled($this->form->password_confirmation)) {
+            $this->validateOnly('password_confirmation');
+        }
+    }
+
+    public function resetPassword()
+    {
+        $this->form->validate();
+
+        try {
+            $password_same_as_current = Hash::check($this->form->password, $this->user->password);
+
+            if ($password_same_as_current) {
+                return session()->flash('error', __('pages/auth/reset-password.messages.same_password'));
+            }
+
+            $updatedUser = $this->userRepository->update($this->user->id, [
+                'password' => $this->form->password,
+                'remember_token' => null,
+            ]);
+
+            if (!$updatedUser) return $this->sendBaseExceptionMessage('User not updated');
+
+            $password_reset_deleted = DB::table('password_reset_tokens')->where('email', $this->user->email)->delete();
+
+            if (!$password_reset_deleted) return $this->sendBaseExceptionMessage('Password reset token not deleted');
+
+            $mail = new \App\Mail\UserPasswordReseted(
+                name: $this->user->name,
+                email: $this->user->email,
+            );
+
+            Mail::to($this->user->email)->send($mail);
+
+            $this->form->reset(['password', 'password_confirmation']);
+
+            return session()->flash('success', __('pages/auth/reset-password.messages.success'));
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+            return $this->sendBaseExceptionMessage($e);
+        }
+    }
+
+    private function sendBaseExceptionMessage($message)
+    {
+        Log::error('ResetPasswordUser: ' . $message);
+        return session()->flash('error', __('pages/auth/reset-password.messages.error'));
+    }
+
+    public function redirectEvent(string $url, int $timeout = 3000)
+    {
+        $this->dispatchBrowserEvent('redirect', ['url' => $url, 'timeout' => $timeout]);
+    }
+
+    public function render()
+    {
+        return view('livewire.reset-password-user', [
+            'token' => $this->token,
+            'email' => $this->user->email,
+        ]);
+    }
+}

--- a/app/Mail/ResetUserPasswordMail.php
+++ b/app/Mail/ResetUserPasswordMail.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ResetUserPasswordMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public string $name,
+        public string $email,
+        public string $token,
+    )
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('mails/reset-user-password.subject'),
+        );
+    }
+
+    /**
+     * Build the message.
+     */
+    public function build(): self
+    {
+        return $this->view('pages.emails.reset-user-password', [
+            'title' => __('mails/reset-user-password.title'),
+            'name' => $this->name,
+            'email' => $this->email,
+            'token' => $this->token,
+        ]);
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/UserPasswordReseted.php
+++ b/app/Mail/UserPasswordReseted.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class UserPasswordReseted extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public string $name,
+        public string $email,
+    )
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('mails/user-password-reseted.title'),
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function build(): self
+    {
+        return $this->view('pages.emails.user-password-reseted', [
+            'title' => __('mails/user-password-reseted.title'),
+            'name' => $this->name,
+            'email' => $this->email,
+        ]);
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/database/migrations/2023_12_25_201340_add_expires_at_to_password_reset_tokens_table.php
+++ b/database/migrations/2023_12_25_201340_add_expires_at_to_password_reset_tokens_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('password_reset_tokens', function (Blueprint $table) {
+            $table->timestamp('expires_at')->default(now()->addHour());
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('password_reset_tokens', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/lang/en/mails/reset-user-password.php
+++ b/lang/en/mails/reset-user-password.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'subject' => 'Reset your password',
+    'title' => 'Reset your password',
+    'presentation' => 'Hello :name,',
+    'message' => 'You are receiving this email because we received a password reset request for your account.',
+    'token_expiration' => 'This password reset link will expire in :count minutes.',
+    'button' => 'Reset Password',
+    'if_youre_having_trouble_clicking_the_button' => 'If you’re having trouble clicking the ":actionText" button, copy and paste the URL below into your web browser:',
+    'copy_and_paste_url' => 'Copy and paste the URL below into your web browser:',
+    'your_requested_a_password_reset_to_email' => 'You requested a password reset to :email. Click the button below to reset your password.',
+    'not_requested_password_reset' => 'If you did not request a password reset, no further action is required.',
+    'footer' => 'If you did not request a password reset, no further action is required.',
+    'regards' => 'Regards, :team Team',
+];

--- a/lang/en/mails/user-password-reseted.php
+++ b/lang/en/mails/user-password-reseted.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'title' => 'Your password has been reseted',
+    'subject' => 'Password reseted.',
+    'presentation' => 'Hello :name,',
+    'message' => 'Your password has been reseted recently. If you did not request this reset, please take immediate action. Contact support or reset your password.',
+    'description' => 'Please login with your new password.',
+    'go_to_login_link' => 'Go to Login',
+    'regards' => 'Regards, :team',
+];

--- a/lang/en/pages/auth/forgot-password.php
+++ b/lang/en/pages/auth/forgot-password.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'title' => 'Forgot your password?',
+    'app_name' => 'Stream Harbor',
+    'attributes' => [
+        'email' => 'email',
+    ],
+    'email_input' => [
+        'placeholder' => 'Enter your email address',
+        'label' => 'Email Address',
+    ],
+    'buttons' => [
+        'submit' => 'Reset my password',
+    ],
+    'messages' => [
+        'success' => 'We have emailed your password reset link!',
+        'error' => 'Something went wrong! Please try again.',
+    ],
+    'form_description' => 'Enter your email address and we will send you a link to reset your password.',
+    'form_footer' => 'Remembered your password?',
+    'form_footer_link' => 'Sign in',
+];

--- a/lang/en/pages/auth/login.php
+++ b/lang/en/pages/auth/login.php
@@ -1,11 +1,12 @@
 <?php
 
 return [
-    "title"=> "Stream Harbor",
+    "title" => "Stream Harbor",
     "form_title" => "Sign in",
     "attributes" => [
         "email" => "email",
         "password" => "password",
+        'remember_me' => 'remember_me',
     ],
     "email_input" => [
         "label" => "Your Email",
@@ -15,6 +16,9 @@ return [
         "label" => "Password",
         "placeholder" => "********",
     ],
+    "remember_me_input" => [
+        "label" => "Remember me",
+    ],
     "form_button" => 'Sign in',
     'form_error' => [
         'credentials_error' => 'Incorrect email or password.',
@@ -22,5 +26,5 @@ return [
     'form_footer' => [
         'does_not_have_an_account' => 'Already have an account?',
         'sign_up_here' => 'Sign up here',
-    ]
+    ],
 ];

--- a/lang/en/pages/auth/login.php
+++ b/lang/en/pages/auth/login.php
@@ -19,6 +19,7 @@ return [
     "remember_me_input" => [
         "label" => "Remember me",
     ],
+    "forgot_password_link" => "Forgot your password?",
     "form_button" => 'Sign in',
     'form_error' => [
         'credentials_error' => 'Incorrect email or password.',

--- a/lang/en/pages/auth/reset-password.php
+++ b/lang/en/pages/auth/reset-password.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'title' => 'Reset Password',
+    'description' => 'Please enter a new password that is different from your previous password to ensure the security of your account. Remember that a strong password contains a combination of letters, numbers, and symbols.',
+    'attributes' => [
+        'password' => 'password',
+        'password_confirmation' => 'password confirmation',
+    ],
+    'password_input' => [
+        'label' => 'Password',
+        'placeholder' => '********',
+    ],
+    'password_confirmation_input' => [
+        'label' => 'Password Confirmation',
+        'placeholder' => '********',
+    ],
+    'messages' => [
+        'success' => 'Your password has been reset successfully.',
+        'error' => 'Something went wrong. Please try again.',
+        'same_password' => 'Your new password cannot be the same as your current password.',
+    ],
+    'submit_button' => 'Reset Password',
+    'go_to_login_link' => 'Go to Login',
+    'register_link' => 'Register',
+];

--- a/lang/pt-br/mails/reset-user-password.php
+++ b/lang/pt-br/mails/reset-user-password.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'subject' => 'Redefinir sua senha',
+    'title' => 'Redefinir sua senha',
+    'presentation' => 'Olá :name,',
+    'message' => 'Você está recebendo este e-mail porque recebemos uma solicitação de redefinição de senha para sua conta.',
+    'token_expiration' => 'Este link de redefinição de senha expirará em :count minutos.',
+    'button' => 'Redefinir senha',
+    'if_youre_having_trouble_clicking_the_button' => 'Se você está tendo problemas para clicar no botão ":actionText", copie e cole a URL abaixo em seu navegador da web:',
+    'copy_and_paste_url' => 'Copie e cole a URL abaixo em seu navegador da web:',
+    'your_requested_a_password_reset_to_email' => 'Você solicitou uma redefinição de senha para :email. Clique no botão abaixo para redefinir sua senha.',
+    'not_requested_password_reset' => 'Se você não solicitou uma redefinição de senha, nenhuma ação adicional será necessária.',
+    'footer' => 'Se você não solicitou uma redefinição de senha, nenhuma ação adicional será necessária.',
+    'regards' => 'Atenciosamente, Equipe :team',
+];

--- a/lang/pt-br/mails/user-password-reseted.php
+++ b/lang/pt-br/mails/user-password-reseted.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'title' => 'Sua senha foi redefinida',
+    'subject' => 'Senha redefinida.',
+    'presentation' => 'Olá :name,',
+    'message' => 'Sua senha foi redefinida recentemente. Se você não solicitou esta redefinição, tome medidas imediatas. Entre em contato com o suporte ou redefina sua senha.',
+    'description' => 'Por favor, faça login com sua nova senha.',
+    'go_to_login_link' => 'Ir para o Login',
+    'regards' => 'Atenciosamente, :team',
+];

--- a/lang/pt-br/pages/auth/forgot-password.php
+++ b/lang/pt-br/pages/auth/forgot-password.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'title' => 'Recuperar senha',
+    'app_name' => 'Stream Harbor',
+    'attributes' => [
+        'email' => 'email',
+    ],
+    'email_input' => [
+        'placeholder' => 'Digite seu endereço de e-mail',
+        'label' => 'Endereço de e-mail',
+    ],
+    'buttons' => [
+        'submit' => 'Redefinir minha senha',
+    ],
+    'messages' => [
+        'success' => 'Enviamos seu link de redefinição de senha por e-mail!',
+        'error' => 'Algo deu errado! Por favor, tente novamente.',
+    ],
+    'form_description' => 'Digite seu endereço de e-mail e enviaremos um link para redefinir sua senha.',
+    'form_footer' => 'Lembrou sua senha?',
+    'form_footer_link' => 'Entrar',
+];

--- a/lang/pt-br/pages/auth/reset-password.php
+++ b/lang/pt-br/pages/auth/reset-password.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'title' => 'Redefinir Senha',
+    'description' => 'Por favor, insira uma nova senha que seja diferente da sua senha anterior para garantir a segurança da sua conta. Lembre-se de que uma senha forte contém uma combinação de letras, números e símbolos.',
+    'attributes' => [
+        'password' => 'senha',
+        'password_confirmation' => 'confirmação de senha',
+    ],
+    'password_input' => [
+        'label' => 'Senha',
+        'placeholder' => '********',
+    ],
+    'password_confirmation_input' => [
+        'label' => 'Confirmação de Senha',
+        'placeholder' => '********',
+    ],
+    'messages' => [
+        'success' => 'Sua senha foi redefinida com sucesso.',
+        'error' => 'Algo deu errado. Por favor, tente novamente.',
+        'same_password' => 'Sua nova senha não pode ser igual à sua senha atual.',
+    ],
+    'submit_button' => 'Redefinir Senha',
+    'go_to_login_link' => 'Ir para o Login',
+    'register_link' => 'Registrar',
+];

--- a/resources/views/components/flowbite/alert.blade.php
+++ b/resources/views/components/flowbite/alert.blade.php
@@ -1,0 +1,57 @@
+@props(['type' => 'default'])
+
+@switch($type)
+    @case('success')
+        <div {{ $attributes->merge(['class' => 'flex gap-2 items-center p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-700 dark:text-green-400']) }}
+            role="alert">
+            <i class="fa-solid fa-circle-info"></i>
+            <span class="sr-only">{{ __('states.success') }}</span>
+            <div>
+                {{ $slot }}
+            </div>
+        </div>
+    @break
+
+    @case('warning')
+        <div {{ $attributes->merge(['class' => 'flex gap-2 items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-700 dark:text-yellow-400']) }}
+            role="alert">
+            <i class="fa-solid fa-circle-info"></i>
+            <span class="sr-only">{{ __('states.info') }}</span>
+            <div>
+                {{ $slot }}
+            </div>
+        </div>
+    @break
+
+    @case('error')
+        <div {{ $attributes->merge(['class' => 'flex gap-2 items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-700 dark:text-red-400']) }}
+            role="alert">
+            <i class="fa-solid fa-circle-info"></i>
+            <span class="sr-only">{{ __('states.info') }}</span>
+            <div>
+                {{ $slot }}
+            </div>
+        </div>
+    @break
+
+    @case('info')
+        <div {{ $attributes->merge(['class' => 'flex gap-2 items-center p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-700 dark:text-blue-400']) }}
+            role="alert">
+            <i class="fa-solid fa-circle-info"></i>
+            <span class="sr-only">{{ __('states.info') }}</span>
+            <div>
+                {{ $slot }}
+            </div>
+        </div>
+    @break
+
+    @default
+        <div {{ $attributes->merge(['class' => 'flex gap-2 items-center p-4 mb-4 text-sm text-gray-800 rounded-lg bg-gray-50 dark:bg-gray-700 dark:text-gray-400']) }}
+            role="alert">
+            <i class="fa-solid fa-circle-info"></i>
+            <span class="sr-only">{{ __('states.info') }}</span>
+            <div>
+                {{ $slot }}
+            </div>
+        </div>
+@endswitch

--- a/resources/views/components/flowbite/checkbox.blade.php
+++ b/resources/views/components/flowbite/checkbox.blade.php
@@ -1,0 +1,5 @@
+<label class="flex items-center justify-between gap-2 ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">
+    <input type="checkbox" {{ $attributes }}
+        class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+    {{ $slot }}
+</label>

--- a/resources/views/components/layouts/email.blade.php
+++ b/resources/views/components/layouts/email.blade.php
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+    <title>{{ $title }}</title>
+
+    {{-- Bladewind --}}
+    <link href="{{ asset('vendor/bladewind/css/animate.min.css') }}" rel="stylesheet" />
+    <link href="{{ asset('vendor/bladewind/css/bladewind-ui.min.css') }}" rel="stylesheet" />
+
+    {{-- Font Awesome --}}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
+        integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+    <link rel="shortcut icon" href="{{ asset('favicon.svg') }}" type="image/x-icon">
+
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @livewireStyles
+    @stack('styles')
+</head>
+
+<body {{ $attributes }}>
+
+    {{ $slot }}
+
+    <script src="{{ asset('vendor/bladewind/js/helpers.js') }}"></script>
+    <script src="//unpkg.com/alpinejs" defer></script>
+    @livewireScripts
+    @stack('scripts')
+</body>
+
+</html>

--- a/resources/views/livewire/create-user.blade.php
+++ b/resources/views/livewire/create-user.blade.php
@@ -6,18 +6,9 @@
     </h1>
 
     @if (session()->has('message'))
-        <div class="flex items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
-            role="alert">
-            <svg class="flex-shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
-                fill="currentColor" viewBox="0 0 20 20">
-                <path
-                    d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
-            </svg>
-            <span class="sr-only">Info</span>
-            <div>
-                {{ session('message') }}
-            </div>
-        </div>
+        <x-flowbite.alert type="error">
+            {{ session('message') }}
+        </x-flowbite.alert>
     @endif
 
     @csrf

--- a/resources/views/livewire/forgot-password-user.blade.php
+++ b/resources/views/livewire/forgot-password-user.blade.php
@@ -1,0 +1,48 @@
+<form wire:submit.prevent="sendEmail"
+    class="p-8 space-y-4 md:space-y-6 border border-gray-200 rounded-lg shadow bg-gray-100 dark:bg-gray-800 dark:border-gray-700">
+
+    <h1 class="font-semibold text-xl text-gray-500 dark:text-gray-400">
+        {{ __('pages/auth/forgot-password.title') }}
+    </h1>
+
+    @csrf
+
+    @if (session()->has('success'))
+        <x-flowbite.alert type="success">
+            {{ session('success') }}
+        </x-flowbite.alert>
+    @elseif (session()->has('error'))
+        <x-flowbite.alert type="error">
+            {{ session('error') }}
+        </x-flowbite.alert>
+    @endif
+
+    <p class="text-sm font-light text-gray-500 dark:text-gray-400">
+        {{ __('pages/auth/forgot-password.form_description') }}
+    </p>
+
+    <div>
+        <x-flowbite.input-label :for="__('pages/auth/forgot-password.attributes.email')" :error="$errors->has('form.email')">
+            {{ __('pages/auth/forgot-password.email_input.label') }}
+        </x-flowbite.input-label>
+
+        <x-flowbite.input wire:model='form.email' :id="__('pages/auth/forgot-password.attributes.email')" :placeholder="__('pages/auth/forgot-password.email_input.placeholder')" :error="$errors->has('form.email')" />
+
+        @error('form.email')
+            <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ $message }}</p>
+        @enderror
+    </div>
+
+    <x-flowbite.button wire:loading.attr='disabled' class="flex gap-2 items-center justify-center">
+        <i wire:loading wire:target='sendEmail' class="fa-solid fa-spinner animate-spin text-lg text-primary-200"></i>
+        <span> {{ __('pages/auth/forgot-password.buttons.submit') }} </span>
+    </x-flowbite.button>
+
+    <p class="text-sm font-light text-gray-500 dark:text-gray-400">
+        {{ __('pages/auth/forgot-password.form_footer') }}
+
+        <x-flowbite.link :href="route('auth.register', ['locale' => app()->getLocale()])">
+            {{ __('pages/auth/forgot-password.form_footer_link') }}
+        </x-flowbite.link>
+    </p>
+</form>

--- a/resources/views/livewire/login-user.blade.php
+++ b/resources/views/livewire/login-user.blade.php
@@ -27,7 +27,7 @@
             {{ __('pages/auth/login.email_input.label') }}
         </x-flowbite.input-label>
 
-        <x-flowbite.input wire:model='credentials.email' :id="__('pages/auth/login.attributes.email')" :placeholder="__('pages/auth/login.email_input.placeholder')" :error="$errors->has('email')" />
+        <x-flowbite.input wire:model='email' :id="__('pages/auth/login.attributes.email')" :placeholder="__('pages/auth/login.email_input.placeholder')" :error="$errors->has('email')" />
     </div>
 
     <div>
@@ -35,7 +35,13 @@
             {{ __('pages/auth/login.password_input.label') }}
         </x-flowbite.input-label>
 
-        <x-flowbite.input wire:model='credentials.password' :id="__('pages/auth/login.attributes.password')" :placeholder="__('pages/auth/login.password_input.placeholder')" type='password' />
+        <x-flowbite.input wire:model='password' :id="__('pages/auth/login.attributes.password')" :placeholder="__('pages/auth/login.password_input.placeholder')" type='password' />
+    </div>
+
+    <div class="flex justify-between items-center">
+        <x-flowbite.checkbox wire:model='remember_me' :id="__('pages/auth/login.attributes.remember_me')">
+            {{ __('pages/auth/login.remember_me_input.label') }}
+        </x-flowbite.checkbox>
     </div>
 
     <x-flowbite.button wire:loading.attr='disabled'>

--- a/resources/views/livewire/login-user.blade.php
+++ b/resources/views/livewire/login-user.blade.php
@@ -42,6 +42,10 @@
         <x-flowbite.checkbox wire:model='remember_me' :id="__('pages/auth/login.attributes.remember_me')">
             {{ __('pages/auth/login.remember_me_input.label') }}
         </x-flowbite.checkbox>
+
+        <x-flowbite.link :href="route('auth.forgot-password', ['locale' => app()->getLocale()])" class="text-sm">
+            {{ __('pages/auth/login.forgot_password_link') }}
+        </x-flowbite.link>
     </div>
 
     <x-flowbite.button wire:loading.attr='disabled'>

--- a/resources/views/livewire/reset-password-user.blade.php
+++ b/resources/views/livewire/reset-password-user.blade.php
@@ -1,0 +1,72 @@
+<form wire:submit.prevent='resetPassword'
+    class="p-8 space-y-4 md:space-y-6 border border-gray-200 rounded-lg shadow bg-gray-100 dark:bg-gray-800 dark:border-gray-700">
+
+    <h1 class="text-2xl font-extrabold leading-none tracking-tight text-gray-900 dark:text-white">
+        {{ __('pages/auth/reset-password.title') }}
+    </h1>
+
+    @csrf
+
+    @if (session()->has('success'))
+        <x-flowbite.alert type="success">
+            {{ session('success') }}
+        </x-flowbite.alert>
+
+        <script>
+            setTimeout(() => Livewire.emit('redirect'), 2000);
+        </script>
+    @elseif (session()->has('error'))
+        <x-flowbite.alert type="error">
+            {{ session('error') }}
+        </x-flowbite.alert>
+    @endif
+
+    <p class="text-sm text-gray-600 dark:text-gray-400">
+        {{ __('pages/auth/reset-password.description') }}
+    </p>
+
+    <div class="space-y-2">
+        <x-flowbite.input-label :for="__('pages/auth/reset-password.attributes.password')" :error="$errors->has('form.password')">
+            {{ __('pages/auth/reset-password.password_input.label') }}
+        </x-flowbite.input-label>
+
+        <x-flowbite.input wire:model.live.200ms='form.password' type='password' :id="__('pages/auth/reset-password.attributes.password')" :placeholder="__('pages/auth/reset-password.password_input.placeholder')"
+            :error="$errors->has('form.password')" />
+
+        @error('form.password')
+            <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ $message }}</p>
+        @enderror
+    </div>
+
+    <div class="space-y-2">
+        <x-flowbite.input-label :for="__('pages/auth/reset-password.attributes.password_confirmation')" :error="$errors->has('form.password_confirmation')">
+            {{ __('pages/auth/reset-password.password_confirmation_input.label') }}
+        </x-flowbite.input-label>
+
+        <x-flowbite.input wire:model.live.200ms='form.password_confirmation' type='password' :id="__('pages/auth/reset-password.attributes.password_confirmation')"
+            :placeholder="__('pages/auth/reset-password.password_confirmation_input.placeholder')" :error="$errors->has('form.password_confirmation')" />
+
+        @error('form.password_confirmation')
+            <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ $message }}</p>
+        @enderror
+    </div>
+
+    <div class="flex items-center justify-between">
+        <a href="{{ route('auth.login', ['locale' => app()->getLocale()]) }}"
+            class="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-500 dark:hover:text-blue-400">
+            {{ __('pages/auth/reset-password.go_to_login_link') }}
+        </a>
+
+        <x-flowbite.button wire:loading.attr='disabled' class="max-w-fit flex gap-2 items-center justify-center">
+            <i wire:loading wire:target='resetPassword'
+                class="fa-solid fa-spinner animate-spin text-lg text-primary-200"></i>
+            <span> {{ __('pages/auth/reset-password.submit_button') }} </span>
+        </x-flowbite.button>
+    </div>
+
+    <script>
+        Livewire.on('redirect', () => {
+            window.location.href = "{{ route('auth.login', ['locale' => app()->getLocale()]) }}"
+        })
+    </script>
+</form>

--- a/resources/views/pages/auth/forgot-password.blade.php
+++ b/resources/views/pages/auth/forgot-password.blade.php
@@ -1,0 +1,15 @@
+<x-layouts.app :title="$title" class="bg-gray-700 h-screen bg-auto bg-no-repeat">
+
+    <img src={{ asset('assets/images/background-image.png') }} alt="Background Image" loading="lazy"
+        class="absolute -z-50 object-cover w-full h-screen overflow-hidden">
+
+    <div class="max-w-md w-full mx-auto">
+
+        <div class="mx-5">
+            <x-favicon-with-title :title="__('pages/auth/forgot-password.app_name')" class="w-48" />
+            @livewire('forgot-password-user')
+        </div>
+
+    </div>
+
+</x-layouts.app>

--- a/resources/views/pages/auth/reset-password.blade.php
+++ b/resources/views/pages/auth/reset-password.blade.php
@@ -1,0 +1,13 @@
+<x-layouts.app :title="$title" class="bg-gray-700 bg-auto bg-no-repeat">
+
+    <img src={{ asset('assets/images/background-image.png') }} alt="Background Image"
+        class="absolute -z-50 object-cover w-full h-screen overflow-hidden">
+
+    <div class="max-w-md w-full mx-auto">
+        <div class="mx-5">
+            <x-favicon-with-title :title="__('pages/auth/register.title')" class="w-48" />
+            @livewire('reset-password-user', ['token' => $token, 'user' => $user])
+        </div>
+    </div>
+
+</x-layouts.app>

--- a/resources/views/pages/emails/reset-user-password.blade.php
+++ b/resources/views/pages/emails/reset-user-password.blade.php
@@ -1,0 +1,50 @@
+<x-layouts.email :title="$title">
+    <div class="max-w-xl mx-auto bg-gray-100 p-5">
+        <p class="text-primary-800 text-center">{{ __('Stream Harbor') }}</p>
+
+        <div class="my-4">
+            <h1 class="mb-4 text-2xl font-extrabold leading-none tracking-tight text-gray-900 dark:text-white">
+                {{ __('mails/reset-user-password.title') }}
+            </h1>
+
+            <h3 class="mt-4 text-lg">
+                {!! __('mails/reset-user-password.presentation', [
+                    'name' => '<span class="font-semibold">' . $name . '</span>',
+                ]) !!}
+            </h3>
+
+            <p>{!! __('mails/reset-user-password.your_requested_a_password_reset_to_email', [
+                'email' => '<span class="font-semibold">' . $email . '</span>',
+            ]) !!}</p>
+
+            <div class="my-6 text-center">
+                <a href="{{ route('auth.reset-password', ['token' => $token, 'email' => $email, 'locale' => app()->getLocale()]) }}"
+                    class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">
+                    {{ __('mails/reset-user-password.button') }}
+                </a>
+            </div>
+
+            <p class="mt-4 text-sm">
+                {{ __('mails/reset-user-password.if_youre_having_trouble_clicking_the_button', ['actionText' => __('mails/reset-user-password.button')]) }}
+                <a href="{{ route('auth.reset-password', ['token' => $token, 'email' => $email, 'locale' => app()->getLocale()]) }}"
+                    class="text-blue-700 hover:text-blue-800 underline">
+                    {{ route('auth.reset-password', ['token' => $token, 'email' => $email, 'locale' => app()->getLocale()]) }}
+                </a>
+            </p>
+
+            <p class="mt-4">
+                <span>{{ __('mails/reset-user-password.not_requested_password_reset') }}</span>
+                <span>{!! __('mails/reset-user-password.token_expiration', [
+                    'count' =>
+                        '<span class="font-semibold">' .
+                        config('auth.passwords.' . config('auth.defaults.passwords') . '.expire') .
+                        '</span>',
+                ]) !!}</span>
+            </p>
+
+            <p class="mt-4">{!! __('mails/reset-user-password.regards', [
+                'team' => '<span class="font-semibold">' . config('app.name') . '</span>',
+            ]) !!}</p>
+        </div>
+    </div>
+</x-layouts.email>

--- a/resources/views/pages/emails/user-password-reseted.blade.php
+++ b/resources/views/pages/emails/user-password-reseted.blade.php
@@ -1,0 +1,25 @@
+<x-layouts.email :title="$title">
+    <div class="max-w-xl mx-auto bg-gray-100 p-5">
+        <p class="text-primary-800 text-center">{{ __('Stream Harbor') }}</p>
+
+        <div class="my-4">
+            <h1 class="mb-4 text-2xl font-extrabold leading-none tracking-tight text-gray-900 dark:text-white">
+                {{ __('mails/user-password-reseted.title', ['email' => $email]) }}
+            </h1>
+
+            <h3 class="mt-4 text-lg">
+                {!! __('mails/user-password-reseted.presentation', [
+                    'name' => '<span class="font-semibold">' . $name . '</span>',
+                ]) !!}
+            </h3>
+
+            <p class="mt-4">
+                {{ __('mails/user-password-reseted.message') }}
+            </p>
+
+            <p class="mt-4">{!! __('mails/user-password-reseted.regards', [
+                'team' => '<span class="font-semibold">' . config('app.name') . '</span>',
+            ]) !!}</p>
+        </div>
+    </div>
+</x-layouts.email>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,10 +17,23 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::group(["prefix" => "{locale}"], function () {
+    // Home
     Route::get('/', [HomeController::class, 'index'])->name('index');
-    Route::get('/auth/register', fn () => view('pages.auth.register', ['title' => 'Sign up']))->name('auth.register');
-    Route::get('/auth/login', fn () => view('pages.auth.login', ['title' => 'Sign in']))->name('auth.login');
 
+    // Authentication
+    Route::group(['prefix' => 'auth', 'as' => 'auth.'], function () {
+        Route::get('/register', [AuthenticationController::class, 'register'])->name('register');
+        Route::get('/login', [AuthenticationController::class, 'login'])->name('login');
+        Route::get('/forgot-password', [AuthenticationController::class, 'forgotPassword'])->name('forgot-password');
+    });
+
+    // Emails
+    Route::group(['prefix' => 'emails', 'as' => 'emails.'], function () {
+        Route::get('/verify', fn () => view('pages.emails.verify', ['title' => 'Verify your email']))->name('verify');
+        Route::get('/reset', fn () => view('pages.emails.reset', ['title' => 'Reset your password']))->name('reset');
+    });
+
+    // Videos
     Route::get('/video/{id}', [VideoController::class, 'show'])->name('videos.show');
 
     require __DIR__ . '/api.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,12 +25,7 @@ Route::group(["prefix" => "{locale}"], function () {
         Route::get('/register', [AuthenticationController::class, 'register'])->name('register');
         Route::get('/login', [AuthenticationController::class, 'login'])->name('login');
         Route::get('/forgot-password', [AuthenticationController::class, 'forgotPassword'])->name('forgot-password');
-    });
-
-    // Emails
-    Route::group(['prefix' => 'emails', 'as' => 'emails.'], function () {
-        Route::get('/verify', fn () => view('pages.emails.verify', ['title' => 'Verify your email']))->name('verify');
-        Route::get('/reset', fn () => view('pages.emails.reset', ['title' => 'Reset your password']))->name('reset');
+        Route::get('/reset-password/{token}', [AuthenticationController::class, 'resetPassword'])->name('reset-password');
     });
 
     // Videos


### PR DESCRIPTION
### Description
This branch adds the funcionality for the user to reset their password. It adds a "remember_me" checkbox in the login page in case the user doesn't want to go through the process of logging in in time to time because of the session expiration time. It also adds a link to the forgot password page so the user can inform their email so that we email them with a reset password link. This link goes to a new page called reset password in which the user must fill a new password that matches the requirements of a password in the sign up page, the user will not be able to change their password if the token or the email are not valid, or if the new password is the same as the old one. To prevent security problems, the reset password token will last for exactly one hour before it gets deleted from the database. I added a new custom command that deletes expired tokens from the database every hour.